### PR TITLE
Custom webmanifest with train # for train pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -189,6 +189,30 @@ async def train_partial(request):
     raise web.HTTPNotFound(reason="Train not found")
 
 
+@routes.get("/trains/{train_number}.webmanifest")
+async def webmanifest(request):
+    data = {
+        "name": "#" + request.match_info["train_number"],
+        "short_name": "#" + request.match_info["train_number"],
+        "icons": [
+            {
+                "src": "/static/favicon/android-chrome-192x192.png",
+                "sizes": "192x192",
+                "type": "image/png",
+            },
+            {
+                "src": "/static/favicon/android-chrome-512x512.png",
+                "sizes": "512x512",
+                "type": "image/png",
+            },
+        ],
+        "theme_color": "#ffffff",
+        "background_color": "#ffffff",
+        "display": "standalone",
+    }
+    return web.json_response(data, dumps=json_dumps)
+
+
 @routes.get("/trains/{train_number}")
 @routes.get("/trains/{train_number}/{train_id}")
 @aiohttp_jinja2.template("train.jinja2")

--- a/templates/base.jinja2
+++ b/templates/base.jinja2
@@ -31,7 +31,9 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/static/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/static/favicon/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/static/favicon/favicon-16x16.png">
+    {% block manifest %}
     <link rel="manifest" href="/static/favicon/site.webmanifest">
+    {% endblock %}
     {% block opengraph %}
     <title>{{ request.headers.get("HOST") }}</title>
     <meta property="og:title" content="{{ request.headers.get('HOST') }}" />
@@ -49,7 +51,7 @@
   <footer style="font-family: serif; margin-top: 1em; width: 100%; max-width: 25em;">
     <div style="width: 100%; font-size: smaller; max-width: 30em; background-color: #FFE1E6; color: #111111; text-align: center;">
       <span style="width: 100%;">This application is being objected to by Amtrak via bogus malware/phishing complaints leading to inaccesibility on some domains.</span><br>
-      <span style="width: 100%;">If you're unable to access it at {{ request.headers.get("HOST") }}, try one of:</span><br> 
+      <span style="width: 100%;">If you're unable to access it at {{ request.headers.get("HOST") }}, try one of:</span><br>
       <span style="width: 100%;">
     {% set domains = ['amtrack.live', 'amtrak.live', 'trains.durbin.ee'] %}
     {% if request.headers.get("HOST") in domains %}

--- a/templates/train.jinja2
+++ b/templates/train.jinja2
@@ -5,6 +5,9 @@
     <meta name="description" content="{{ train["route_name"] }} #{{ train["train_number"] }} - Ultra-lightweight Amtrak train status tracker.">
     <meta property="og:description" content="{{ train["route_name"] }} #{{ train["train_number"] }} - Ultra-lightweight Amtrak train status tracker.">
 {% endblock %}
+{% block manifest %}
+    <link rel="manifest" href="/trains/{{ train["train_number"] }}.webmanifest" />
+{% endblock %}
 {% block content %}
 <h1 style="margin-block-end: .25em; margin-block-start: .25em;">{{ train["route_name"] }} #{{ train["train_number"] }}</h1>
 <p style="margin-block-end: .25em; margin-block-start: .25em;"><small>Initial Departure: {{ train["departure_date"].strftime("%Y-%m-%d") }}</small></p>


### PR DESCRIPTION
When I'm on the train, I work on the train app.

This should have the effect of making the PWA app icon just the short train number, e.g. "#644" rather than the full page title "amtrak.live - Keystone #644"